### PR TITLE
Anti evasion

### DIFF
--- a/evalhook.c
+++ b/evalhook.c
@@ -8,10 +8,13 @@
 
 static const char module_name[] = "evalhook";
 
-static zend_op_array* (*old_compile_string)(zend_string *source_string, const char *filename);
+static zend_op_array* (*old_compile_string)(zend_string *, const char *, zend_compile_position);
 
 
-static zend_op_array* evalhook_compile_string(zend_string *source_string, const char *filename)
+static zend_op_array* evalhook_compile_string(
+		zend_string *source_string,
+		const char *filename,
+		zend_compile_position pos)
 {
 	zend_op_array *op_array = NULL;
 	int op_compiled = 0;
@@ -29,7 +32,7 @@ static zend_op_array* evalhook_compile_string(zend_string *source_string, const 
 			if(call_user_function(CG(function_table), NULL, &function, &retval, 2, parameter) == SUCCESS) {
 				switch(Z_TYPE(retval)) {
 					case IS_STRING:
-						op_array = old_compile_string(Z_STR(retval), filename);
+						op_array = old_compile_string(Z_STR(retval), filename, pos);
 					case IS_FALSE:
 						op_compiled = 1;
 						break;
@@ -45,7 +48,7 @@ static zend_op_array* evalhook_compile_string(zend_string *source_string, const 
 	if(op_compiled) {
 		return op_array;
 	} else {
-		return old_compile_string(source_string, filename);
+		return old_compile_string(source_string, filename, pos);
 	}
 }
 

--- a/evalhook.c
+++ b/evalhook.c
@@ -67,7 +67,7 @@ ZEND_NAMED_FUNCTION(evalhook_extension_loaded)
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_STR(module)
-		ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (zend_string_equals_cstr(module, module_name, sizeof module_name) == 0) {
 		RETURN_FALSE;
@@ -86,7 +86,7 @@ PHP_MINIT_FUNCTION(evalhook)
 #endif
 
 	zend_function * original =
-		zend_hash_str_find_ptr( CG(function_table), "extension_loaded", sizeof("extension_loaded") - 1);
+		zend_hash_str_find_ptr(CG(function_table), "extension_loaded", sizeof "extension_loaded" - 1);
 
 	if (original) {
 		original_handler_extension_loaded = original->internal_function.handler;

--- a/tests/detect-evasion.phpt
+++ b/tests/detect-evasion.phpt
@@ -1,0 +1,28 @@
+--TEST--
+evalhook: detect evasion
+--EXTENSIONS--
+evalhook
+--FILE--
+<?php
+require __DIR__ . '/evalhook_test_functions.inc';
+
+if (extension_loaded('evalhook')
+  || extension_loaded('Evalhook')
+  || extension_loaded('EvalHook')
+  || extension_loaded('EVALHOOK')
+  || extension_loaded('eval_hook')
+  || extension_loaded('Eval_hook')
+  || extension_loaded('Eval_Hook')
+  || extension_loaded('EVAL_HOOK'))
+{
+  echo "evalhook extension detected! Exiting." . PHP_EOL;
+  exit;
+}
+
+eval("echo 'Hello there!';");
+?>
+--EXPECT--
+===== Dump of eval'd code =====
+echo 'Hello there!';
+===== End of dumped code =====
+Hello there!

--- a/tests/evalhook.phpt
+++ b/tests/evalhook.phpt
@@ -1,0 +1,15 @@
+--TEST--
+evalhook: simple eval
+--EXTENSIONS--
+evalhook
+--FILE--
+<?php
+require __DIR__ . '/evalhook_test_functions.inc';
+
+eval("echo 'Hello there!';");
+?>
+--EXPECT--
+===== Dump of eval'd code =====
+echo 'Hello there!';
+===== End of dumped code =====
+Hello there!

--- a/tests/evalhook_test_functions.inc
+++ b/tests/evalhook_test_functions.inc
@@ -1,0 +1,6 @@
+<?php
+function __eval(string $code) {
+	echo PHP_EOL . "===== Dump of eval'd code =====" . PHP_EOL;
+	echo $code;
+	echo PHP_EOL . "===== End of dumped code =====" . PHP_EOL;
+}


### PR DESCRIPTION
We have detected some samples that try to evade deobfuscation by checking if the evalhook extension is loaded, and refusing to run if it is. So I added a simple hook to bypass this evasion.

I'm also including a patch that fixes a warning about incompatible pointer types when manipulating the pointers for the compile_string function.

Also added a couple of very minimal tests.